### PR TITLE
Added export and import windows for settings

### DIFF
--- a/EventProtocol.md
+++ b/EventProtocol.md
@@ -14,6 +14,15 @@ Will be send if auto_hide activates
 ```
 
 
+## ``skip_image``
+
+Skips the current background image, also unlockes the current lock state
+
+```json
+{ }
+```
+
+
 ## ``settings_window_state``
 
 Will be send to open/close the settings panel
@@ -25,32 +34,35 @@ Will be send to open/close the settings panel
 ```
 
 
-## ``skip_image``
+## `import_window_state`
 
-Skips the current background image, also unlockes the current lock state
+Will be send to open/close the import settings window
 
 ```json
-{ }
+{
+    "opened": [true/false]
+}
 ```
 
-## ``url_add_window``
+
+## ``url_add_window_state``
 
 Is being send when user clicks on "+" (Add Image) (Settings -> Playlists, last element)
 
 ```json
 {
-    "open": [true, false]
+    "opened": [true, false]
 }
 ```
 
 
-## ``full_screen_image``
+## ``full_screen_image_window_state``
 
 Is being send when user clicks on the fullscreen icon on any image (Settings -> Playlists)
 
 ```json
 {
-    "url": "the url of the image to display"
+    "url": "none if the window should close else the url of the image to display"
 }
 ```
 

--- a/EventProtocol.md
+++ b/EventProtocol.md
@@ -45,6 +45,17 @@ Will be send to open/close the import settings window
 ```
 
 
+## `export_window_state`
+
+Wil be send to open/close the import settings window
+
+```json
+{
+    "opened": [true/false]
+}
+```
+
+
 ## ``url_add_window_state``
 
 Is being send when user clicks on "+" (Add Image) (Settings -> Playlists, last element)

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "axios": "^0.21.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-json-view": "^1.21.3",
     "react-scripts": "^4.0.3",
     "web-vitals": "^1.1.2"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -10,6 +10,7 @@ import ControlBar from "./components/custom_components/control_bar/controlbar";
 import SettingsComponent from "./components/settings/SettingsComponent";
 import EventHandler from './utils/eventhandler';
 import ImportSettingsComponent from './components/import_export_settings/ImportSettingsComponent';
+import ExportSettingsComponent from './components/import_export_settings/ExportSettingsComponent';
 
 class App extends React.Component {
   constructor(props) {
@@ -20,7 +21,9 @@ class App extends React.Component {
 
     this.state = {
 		  addUrlDialog: false,
-    	fullSizeImage: null
+    	fullSizeImage: null,
+      importSettingsDialog: false,
+      exportSettingsDialog: false
     };
   }
 
@@ -35,28 +38,27 @@ class App extends React.Component {
 
   componentDidMount() {
     EventHandler.listenEvent("url_add_window_state", "app", (data) => {
-      this.setState({
-        addUrlDialog: data.opened
-      });
+      this.setState({ addUrlDialog: data.opened });
     });
 
     EventHandler.listenEvent("full_screen_image_window_state", "app", (data) => {
-      	this.setState({
-        	fullSizeImage: data.url
-      	});
+      	this.setState({ fullSizeImage: data.url });
     });
 
     EventHandler.listenEvent("import_window_state", "app", (data) => {
-      this.setState({
-        importSettingsDialog: data.opened
-      })
-    })
+      this.setState({ importSettingsDialog: data.opened });
+    });
+
+    EventHandler.listenEvent("export_window_state", "app", (data) => {
+      this.setState({ exportSettingsDialog: data.opened });
+    });
   }
 
   componentWillUnmount() {
     EventHandler.unlistenEvent("url_add_window_state", "app");
     EventHandler.unlistenEvent("full_screen_image_window_state", "app");
     EventHandler.unlistenEvent("import_window_state", "app");
+    EventHandler.unlistenEvent("export_window_state", "app");
   }
 
   render() {
@@ -71,6 +73,7 @@ class App extends React.Component {
           {this.state.addUrlDialog ? <URLAddComponent /> : null}
           {this.state.fullSizeImage ? <FullSizeImage url={this.state.fullSizeImage} /> : null}
           {this.state.importSettingsDialog ? <ImportSettingsComponent /> : null}
+          {this.state.exportSettingsDialog ? <ExportSettingsComponent /> : null}
         </Background>
       </div>
     );

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Clock from './components/custom_components/clock/clock';
 import ControlBar from "./components/custom_components/control_bar/controlbar";
 import SettingsComponent from "./components/settings/SettingsComponent";
 import EventHandler from './utils/eventhandler';
+import ImportSettingsComponent from './components/import_export_settings/ImportSettingsComponent';
 
 class App extends React.Component {
   constructor(props) {
@@ -33,22 +34,29 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    EventHandler.listenEvent("url_add_window", "app", (data) => {
+    EventHandler.listenEvent("url_add_window_state", "app", (data) => {
       this.setState({
-        addUrlDialog: data.open
+        addUrlDialog: data.opened
       });
     });
 
-    EventHandler.listenEvent("full_screen_image", "app", (data) => {
+    EventHandler.listenEvent("full_screen_image_window_state", "app", (data) => {
       	this.setState({
         	fullSizeImage: data.url
       	});
+    });
+
+    EventHandler.listenEvent("import_window_state", "app", (data) => {
+      this.setState({
+        importSettingsDialog: data.opened
+      })
     })
   }
 
   componentWillUnmount() {
-    EventHandler.unlistenEvent("url_add_window", "app");
-    EventHandler.unlistenEvent("full_screen_image", "app");
+    EventHandler.unlistenEvent("url_add_window_state", "app");
+    EventHandler.unlistenEvent("full_screen_image_window_state", "app");
+    EventHandler.unlistenEvent("import_window_state", "app");
   }
 
   render() {
@@ -62,6 +70,7 @@ class App extends React.Component {
           <SettingsComponent />
           {this.state.addUrlDialog ? <URLAddComponent /> : null}
           {this.state.fullSizeImage ? <FullSizeImage url={this.state.fullSizeImage} /> : null}
+          {this.state.importSettingsDialog ? <ImportSettingsComponent /> : null}
         </Background>
       </div>
     );

--- a/src/components/import_export_settings/ExportSettingsComponent.js
+++ b/src/components/import_export_settings/ExportSettingsComponent.js
@@ -1,0 +1,51 @@
+import React from "react";
+import EventHandler from "../../utils/eventhandler";
+import ReactJson from 'react-json-view'
+import getUserSettings from "../../utils/settings";
+import './exportsettingscomponent.css';
+
+
+class ExportSettingsComponent extends React.Component {
+    onCopyClick() {
+        const wholeSettings = getUserSettings().retrieveWhole();
+
+        // copy to clipboard
+        navigator.clipboard.writeText(JSON.stringify(wholeSettings));
+    }
+
+    onCloseClick() {
+        EventHandler.triggerEvent("export_window_state", { opened: false });
+    }
+
+    render() {
+        return (
+            <div className="export_settings__container">
+                <div className="export_settings__background">
+                    <div className="export_settings">
+                        <header>
+                            <h2 className="export_settings__heading">Export Settings</h2>
+                        </header>
+                        <div className="export_settings__content">
+                            <p id="export_settings__hint">The json data below is stored in your localstorage</p>
+                            <ReactJson 
+                                src={getUserSettings().retrieveWhole()}
+                                style={{"border": "1px solid rgba(0,0,0,0.2)", "border-radius": "14px", "padding": "10px", "margin-top": "10px"}}
+                                name={false}
+                                collapsed={true}
+                                collapseStringsAfterLength={65}
+                                displayDataTypes={false}
+                                enableClipboard={false}
+                            />
+                        </div>
+                        <div className="export_settings__footer">
+                            <button id="export_settings__copy_btn" onClick={this.onCopyClick}>Copy</button>
+                            <button id="export_settings__close_btn" onClick={this.onCloseClick}>Close</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default ExportSettingsComponent;

--- a/src/components/import_export_settings/ImportSettingsComponent.js
+++ b/src/components/import_export_settings/ImportSettingsComponent.js
@@ -1,5 +1,6 @@
 import React from "react";
 import EventHandler from "../../utils/eventhandler";
+import getUserSettings from "../../utils/settings";
 import './importsettingscomponent.css';
 
 
@@ -23,8 +24,12 @@ class ImportSettingsComponent extends React.Component {
                 alert("The data you entered is not valid JSON");
                 return;
             }
-
+            
+            getUserSettings().overrideSettings(JSON.parse(this.state.settingsData));
             EventHandler.triggerEvent("import_window_state", { opened: false });
+
+            // reload the page
+            window.location.reload();
         } else {
             EventHandler.triggerEvent("import_window_state", { opened: false });
         }

--- a/src/components/import_export_settings/ImportSettingsComponent.js
+++ b/src/components/import_export_settings/ImportSettingsComponent.js
@@ -1,0 +1,62 @@
+import React from "react";
+import EventHandler from "../../utils/eventhandler";
+import './importsettingscomponent.css';
+
+
+class ImportSettingsComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        
+        this.buttonClick = this.buttonClick.bind(this);
+        this.onInputChange = this.onInputChange.bind(this);
+        this.state = {
+            settingsData: ""
+        }
+    }
+    
+    buttonClick(shouldAdd) {
+        if (shouldAdd) {
+            // check if the content of this.state.settingsData is valid json
+            try {
+                JSON.parse(this.state.settingsData);
+            } catch (e) {
+                alert("The data you entered is not valid JSON");
+                return;
+            }
+
+            EventHandler.triggerEvent("import_window_state", { opened: false });
+        } else {
+            EventHandler.triggerEvent("import_window_state", { opened: false });
+        }
+    }
+
+    onInputChange(e) {
+        this.setState({
+            settingsData: e.target.value
+        });
+    }
+
+    render() {
+        return (
+            <div className="import_settings__container">
+                <div className="import_settings__background">
+                    <div className="import_settings">
+                        <header>
+                            <h2 className="import_settings__heading">Import Settings</h2>
+                        </header>
+                        <div className="import_settings__content">
+                            <p id="import_settings__hint">We only accept json data</p>
+                            <input value={this.state.url} onInput={this.onInputChange}></input>
+                        </div>
+                        <div className="import_settings__footer">
+                            <button id="import_settings__cancel_btn" onClick={() => this.buttonClick(false)}>Cancel</button>
+                            <button id="import_settings__submit_btn" onClick={() => this.buttonClick(true)}>Import</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        )
+    }
+}
+
+export default ImportSettingsComponent;

--- a/src/components/import_export_settings/exportsettingscomponent.css
+++ b/src/components/import_export_settings/exportsettingscomponent.css
@@ -1,0 +1,100 @@
+:root {
+    --button-color: rgba(24, 127, 245, 1);
+    --button-alpha-color: rgba(24, 127, 245, 0.7);
+}
+
+.export_settings__container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+}
+
+.export_settings__background {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+.export_settings {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    padding: 3em;
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    align-content: center;
+    gap: 2.5em;
+    box-shadow: 0 0 1em rgba(0, 0, 0, 0.4);
+}
+
+.export_settings__heading {
+    font-weight: 400;
+    margin: 0;
+}
+
+.export_settings__content {
+    flex: 1 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#export_settings__hint {
+    font-size: 0.9em;
+    color: #999;
+    margin-bottom: 0.5em;
+    margin-top: -0.3em;
+}
+
+.export_settings__content input {
+    flex: 1 1;
+    padding: 0.5em;
+    font-size: 1em;
+    border-radius: 4px;
+    border: 1.5px solid black;
+    width: 20em;
+}
+
+.export_settings__footer {
+    display: flex;
+    justify-content: space-around;
+    gap: 1em;
+}
+
+.export_settings__footer button {
+    padding: 0.6em;
+    font-size: 1.1em;
+    border-radius: 4px;
+    border: none;
+    width: 100%;
+    cursor: pointer;
+}
+
+#export_settings__copy_btn {
+    --button-color: rgba(24, 127, 245, 1);
+    --button-alpha-color: rgba(24, 127, 245, 0.7);
+
+    background-color: var(--button-color);
+    color: white;
+}
+
+#export_settings__copy_btn:hover {
+    background-color: var(--button-alpha-color);
+}
+
+#export_settings__close_btn {
+    background-color: transparent;
+    color: var(--button-color);
+    border: 2px solid var(--button-color);
+}
+
+#export_settings__close_btn:hover {
+    filter: brightness(0.9);
+    box-shadow: 0 0 0.7em var(--button-alpha-color);
+}

--- a/src/components/import_export_settings/importsettingscomponent.css
+++ b/src/components/import_export_settings/importsettingscomponent.css
@@ -1,0 +1,97 @@
+:root {
+    --button-color: rgba(24, 127, 245, 1);
+    --button-alpha-color: rgba(24, 127, 245, 0.7);
+}
+
+.import_settings__container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 9999;
+}
+
+.import_settings__background {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+}
+
+.import_settings {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    padding: 3em;
+    border-radius: 16px;
+    display: flex;
+    flex-direction: column;
+    align-content: center;
+    gap: 2.5em;
+    box-shadow: 0 0 1em rgba(0, 0, 0, 0.4);
+}
+
+.import_settings__heading {
+    font-weight: 400;
+    margin: 0;
+}
+
+.import_settings__content {
+    flex: 1 1;
+    display: flex;
+    flex-direction: column;
+}
+
+#import_settings__hint {
+    font-size: 0.9em;
+    color: #999;
+    margin-bottom: 0.5em;
+    margin-top: -0.3em;
+}
+
+.import_settings__content input {
+    flex: 1 1;
+    padding: 0.5em;
+    font-size: 1em;
+    border-radius: 4px;
+    border: 1.5px solid black;
+    width: 20em;
+}
+
+.import_settings__footer {
+    display: flex;
+    justify-content: space-around;
+    gap: 1em;
+}
+
+.import_settings__footer button {
+    padding: 0.6em;
+    font-size: 1.1em;
+    border-radius: 4px;
+    border: none;
+    width: 100%;
+    cursor: pointer;
+}
+
+#import_settings__submit_btn {
+    background-color: var(--button-color);
+    color: white;
+}
+
+#import_settings__submit_btn:hover {
+    background-color: var(--button-alpha-color);
+}
+
+#import_settings__cancel_btn {
+    background-color: transparent;
+    color: var(--button-color);
+    border: 2px solid var(--button-color);
+}
+
+#import_settings__cancel_btn:hover {
+    filter: brightness(0.9);
+    box-shadow: 0 0 0.7em var(--button-alpha-color);
+}

--- a/src/components/settings/widget_settings/WidgetSettingsComponent.js
+++ b/src/components/settings/widget_settings/WidgetSettingsComponent.js
@@ -3,9 +3,18 @@ import './widgetsettingscomponent.css';
 import CustomComponentRegistry from '../../../utils/customcomponentregistry';
 import SettingsElement from './SettingsElement';
 import IS_DEV from '../../../utils/devutils';
+import EventHandler from '../../../utils/eventhandler';
 
 
 class WidgetSettingsComponent extends React.Component {
+    onImportClick() {
+        EventHandler.triggerEvent("import_window_state", { opened: true });
+    }
+
+    onExportClick() {
+        EventHandler.triggerEvent("export_window_state", { opened: true });
+    }
+
     render() {
         return (
             <React.Fragment>
@@ -18,8 +27,8 @@ class WidgetSettingsComponent extends React.Component {
                     })
                 }
                 <div class="widget_settings__import_export">
-                    <button class="widget_settings__import_btn">Import</button>
-                    <button class="widget_settings__export_btn">Export</button>
+                    <button class="widget_settings__import_btn" onClick={this.onImportClick}>Import</button>
+                    <button class="widget_settings__export_btn" onClick={this.onExportClick}>Export</button>
                 </div>
                 <footer id="widget_settings__footer">
                     <div className="widget_settings__footer_urls">

--- a/src/components/settings/widget_settings/WidgetSettingsComponent.js
+++ b/src/components/settings/widget_settings/WidgetSettingsComponent.js
@@ -17,6 +17,10 @@ class WidgetSettingsComponent extends React.Component {
                         return <SettingsElement data={CustomComponentRegistry.get(dataKey)} key={CustomComponentRegistry.get(dataKey).name} />
                     })
                 }
+                <div class="widget_settings__import_export">
+                    <button class="widget_settings__import_btn">Import</button>
+                    <button class="widget_settings__export_btn">Export</button>
+                </div>
                 <footer id="widget_settings__footer">
                     <div className="widget_settings__footer_urls">
                         <a href="https://github.com/aridevelopment-de/myanimetab">

--- a/src/components/settings/widget_settings/widgetsettingscomponent.css
+++ b/src/components/settings/widget_settings/widgetsettingscomponent.css
@@ -1,5 +1,44 @@
-#widget_settings__footer {
+/* import / export buttons */
+
+.widget_settings__import_export {
     margin-top: 5em;
+    display: flex;
+    justify-content: space-around;
+    align-items: center;
+    gap: 1em;
+}
+
+.widget_settings__import_export button {
+    width: 100%;
+    height: 2.5em;
+    border: none;
+    border-radius: 6px;
+    color: #fff;
+    font-size: 1.1em;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.widget_settings__import_btn {
+    background-color: #2ec36c;
+}
+
+.widget_settings__export_btn {
+    background-color: #3498db;
+}
+
+.widget_settings__import_btn:hover {
+    background-color: #27a35b;
+}
+
+.widget_settings__export_btn:hover {
+    background-color: #2a7cb3;
+}
+
+/* social media / copyright */
+
+#widget_settings__footer {
+    margin-top: 3em;
     padding: 0 1em;
     display: flex;
     flex-direction: column;

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -15,6 +15,15 @@ class UserSettings {
         this.settings = {};
     }
 
+    overrideSettings(new_settings) {
+        this.settings = new_settings;
+        this.saveSettings();
+
+        for (let key in this.settings) {
+            EventHandler.triggerEvent(`set.${key}`, {value: this.settings[key]});
+        }
+    }
+
     loadSettings() {
         this.settings = JSON.parse(localStorage.getItem('settings'));
 

--- a/src/utils/settings.js
+++ b/src/utils/settings.js
@@ -15,6 +15,10 @@ class UserSettings {
         this.settings = {};
     }
 
+    retrieveWhole() {
+        return this.settings;
+    }
+
     overrideSettings(new_settings) {
         this.settings = new_settings;
         this.saveSettings();


### PR DESCRIPTION
This pull request includes
- Two buttons added on the general settings page
  - "Import" (opens the import settings window)
  - "Export" (opens the export settings window)
- An import settings window
- An export settings window using a [library](https://github.com/mac-s-g/react-json-view) to display the json data

Closes #15 