### PR TITLE
Cleaned up event names and fixed bug

### DIFF
--- a/src/components/custom_components/clock/clock.js
+++ b/src/components/custom_components/clock/clock.js
@@ -100,14 +100,15 @@ class Clock extends React.Component {
         if (!data.value) {
             if (this.state.intervalId !== undefined) {
                 clearInterval(this.state.intervalId);
-
+                
                 this.setState({
                     intervalId: undefined,
-                    showing: false
+                    showing: false,
+                    opacity: 1
                 });
             }
         } else {
-            this.setState({ showing: true });
+            this.setState({ showing: true, opacity: 0 });
             this.startInterval();
         }
     }

--- a/src/components/settings/playlist_settings/FullSizeImageComponent.js
+++ b/src/components/settings/playlist_settings/FullSizeImageComponent.js
@@ -12,7 +12,7 @@ class ZoomedImage extends React.Component {
     }
 
     onImageClose() {
-        EventHandler.triggerEvent("full_screen_image", { url: null });
+        EventHandler.triggerEvent("full_screen_image_window_state", { url: null });
     }
 
     render() {

--- a/src/components/settings/playlist_settings/PlaylistSettingsComponent.js
+++ b/src/components/settings/playlist_settings/PlaylistSettingsComponent.js
@@ -59,7 +59,7 @@ class PlaylistSettingsComponent extends React.Component {
     }
 
     onResizeClick(idx) {
-        EventHandler.triggerEvent("full_screen_image", { url: this.state.images[idx] });
+        EventHandler.triggerEvent("full_screen_image_window_state", { url: this.state.images[idx] });
     }
 
     onDeleteClick(idx) {
@@ -73,7 +73,7 @@ class PlaylistSettingsComponent extends React.Component {
     }
 
     openURLAddWindow() {
-        EventHandler.triggerEvent("url_add_window", {open: true});
+        EventHandler.triggerEvent("url_add_window_state", {opened: true});
     }
 
     render() {

--- a/src/components/url_add/URLAddComponent.js
+++ b/src/components/url_add/URLAddComponent.js
@@ -15,7 +15,7 @@ class URLAddComponent extends React.Component {
     }
     
     buttonClick(shouldAdd) {
-        EventHandler.triggerEvent("url_add_window", { open: false });
+        EventHandler.triggerEvent("url_add_window_state", { opened: false });
         EventHandler.triggerEvent("playlist_refresh", {});
 
         if (shouldAdd) {


### PR DESCRIPTION
This pull request contains
- A cleanup of the event names used for opening modals (``"<name>_window_state", data: { opened: true/false }``)
- A bugfix for a bug that occured when trying to toggle the clock

