### PR TITLE
Fixed dotsfont on password input field placeholder in settings page

### DIFF
--- a/src/components/settings/widget_settings/SettingsItemInput.js
+++ b/src/components/settings/widget_settings/SettingsItemInput.js
@@ -33,7 +33,7 @@ class SettingsItemInput extends React.Component {
                     onBlur={(e) => {e.target.setAttribute("readonly", "readonly")}}
                     value={this.state.input} 
                     style={{
-                        fontFamily: this.props.hidden ? "dotsfont" : "inherit",
+                        fontFamily: this.props.hidden && this.state.input !== "" ? "dotsfont" : "inherit",
                     }}
                     type="text"
                     spellCheck="false"


### PR DESCRIPTION
Closes #59 

This pull request fixes
- the dotsfont being on the password input field when there was no text. This was messing up the placeholdere