### PR TITLE
Added queues to image playlist

### DIFF
--- a/src/BackgroundComponent.tsx
+++ b/src/BackgroundComponent.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { useEffect, useState } from "react";
+import { useLiveQuery } from "dexie-react-hooks";
+import { useEffect, useState, useCallback } from "react";
 import styles from "./App.module.css";
 import AutoHideScheduler from "./components/AutoHideScheduler";
-import { IImage, metaDb, useMeta, widgetsDb } from "./utils/db";
+import { IImage, IQueue, metaDb, useMeta, widgetsDb } from "./utils/db";
 import EventHandler from "./utils/eventhandler";
 import { useSetting } from "./utils/eventhooks";
 
@@ -12,68 +13,19 @@ const playlistOrderValues = ["Ordered", "Shuffled"];
 
 function Background(props: any) {
 	const [blur, setBlur] = useState(false);
-	const [currentBackgroundUrl, setCurrentBackgroundUrl] = useState("");
-	const currentBackgroundIdx = useMeta("selected_image", (id: number) => {
-		metaDb
-			.getImage(id)
-			.then((image: IImage | undefined) =>
-				setCurrentBackgroundUrl(image ? image.url : "")
-			);
-	});
+	const background = useLiveQuery(async () =>
+		metaDb.images.get((await metaDb.meta.get("selected_image"))?.value)
+	);
+	/* 
 	const [whenWallpaperSwitch, _1] = useSetting("wallpaper-0", "when_switch");
 	const [shouldWallpaperSwitch, _2] = useSetting("wallpaper-0", "state");
-
-	const nextImage = () => {
-		widgetsDb
-			.getSetting("wallpaper-0", "playlist_order")
-			.then((value: number) => {
-				const playlistOrder: string = playlistOrderValues[value];
-
-				/* metaDb.getMeta("images").then((images: string[]) => {
-					if (images.length >= 1) {
-						if (playlistOrder === "Ordered") {
-							let idx = currentBackgroundIdx || 0;
-							idx = (idx + 1) % images.length;
-							metaDb.setMeta("selected_image", idx);
-						} else if (playlistOrder === "Shuffled") {
-							const idx = Math.floor(
-								Math.random() * images.length
-							);
-							metaDb.setMeta("selected_image", idx);
-						}
-					}
-				}); */
-			});
-	};
-
-	EventHandler.on("skip_image", "background", nextImage);
-	EventHandler.on("select_image", "background", (data: { idx: number }) => {
-		metaDb.setMeta("selected_image", data.idx);
-		console.log(data.idx);
-	});
-
-	// Background switch interval
-	useEffect(() => {
-		let interval: ReturnType<typeof setInterval>;
-		const switchInterval: number | null = switchValues[whenWallpaperSwitch];
-
-		if (shouldWallpaperSwitch) {
-			if (switchInterval !== null) {
-				interval = setInterval(
-					nextImage,
-					1000 * switchInterval || 60000
-				);
-			}
-
-			return () => clearInterval(interval);
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [whenWallpaperSwitch, shouldWallpaperSwitch]);
-
+ */
 	return (
 		<div
 			className={styles.background}
-			style={{ backgroundImage: `url(${currentBackgroundUrl})` }}
+			style={{
+				backgroundImage: `url(${(background || { url: "" }).url})`,
+			}}
 		>
 			<AutoHideScheduler setBlur={setBlur} blur={blur} />
 			{props.children(blur)}

--- a/src/components/settings/playlist_settings/PlaylistSettingsComponent.tsx
+++ b/src/components/settings/playlist_settings/PlaylistSettingsComponent.tsx
@@ -141,7 +141,7 @@ function PlaylistSettingsComponent(props: { bodyRef: any }) {
 			.split(",")
 			.map((url: string) => url.trim());
 
-		metaDb.addBulkImages(imagesToAdd);
+		metaDb.addBulkImages(imagesToAdd, currentFolder);
 		setAddImageModalState(false);
 
 		setTimeout(
@@ -230,10 +230,11 @@ function PlaylistSettingsComponent(props: { bodyRef: any }) {
 								<Menu.Item
 									color="red"
 									onClick={() => {
-										metaDb.removeImage(file.id);
-										metaDb
-											.getImages(currentFolder.id)
-											.then(setImages);
+										metaDb.removeImage(file.id).then(() => {
+											metaDb
+												.getImages(currentFolder.id)
+												.then(setImages);
+										});
 									}}
 								>
 									Delete

--- a/src/components/settings/playlist_settings/PlaylistSettingsComponent.tsx
+++ b/src/components/settings/playlist_settings/PlaylistSettingsComponent.tsx
@@ -21,6 +21,7 @@ import {
 import Background from "./filetypes/background";
 import Folder from "./filetypes/folder";
 import styles from "./playlistsettingscomponent.module.css";
+import Queue from "./queue/Queue";
 import EditFolderDialog from "./subcomponents/editfolder";
 import EditImageDialog from "./subcomponents/editimage";
 import TimeLine from "./subcomponents/timeline";
@@ -348,6 +349,7 @@ function PlaylistSettingsComponent(props: { bodyRef: any }) {
 						right-clicking on the menu
 					</Text>
 				) : null}
+				<Queue />
 			</div>
 		</>
 	);

--- a/src/components/settings/playlist_settings/filetypes/background.tsx
+++ b/src/components/settings/playlist_settings/filetypes/background.tsx
@@ -1,6 +1,9 @@
 import styles from "./background.module.css";
 import globalstyles from "../playlistsettingscomponent.module.css";
-import { IImage } from "../../../../utils/db";
+import { IImage, metaDb } from "../../../../utils/db";
+import { Checkbox } from "@mantine/core";
+import { useEffect, useState } from "react";
+import { showNotification } from "@mantine/notifications";
 
 const Background = (props: {
 	image: IImage;
@@ -8,6 +11,50 @@ const Background = (props: {
 	selected: boolean;
 	setDraggedElement: Function;
 }) => {
+	const [isInQueue, setIsInQueue] = useState<boolean>(false);
+	const [hovered, setHovered] = useState<boolean>(false);
+
+	useEffect(() => {
+		metaDb.getMeta("selected_queue").then((value: any) => {
+			if (value !== null) {
+				metaDb
+					.queueContainsImage(value, props.image)
+					.then(setIsInQueue);
+			}
+		});
+	}, [props.image]);
+
+	const setQueueStatus = (addToQueue: boolean) => {
+		metaDb.getMeta("selected_queue").then((value: any) => {
+			if (value === null) {
+				showNotification({
+					title: "No queue selected",
+					message:
+						"Please select a queue first to add the image to it",
+					color: "red",
+				});
+			} else {
+				if (addToQueue) {
+					metaDb
+						.insertImageToQueue(value, props.image)
+						.then((success: boolean) => {
+							if (success) {
+								setIsInQueue(true);
+							}
+						});
+				} else {
+					metaDb
+						.removeImageFromQueue(value, props.image)
+						.then((success: boolean) => {
+							if (success) {
+								setIsInQueue(false);
+							}
+						});
+				}
+			}
+		});
+	};
+
 	return (
 		<div
 			className={`${globalstyles.element_container} ${styles.image_container}`}
@@ -36,7 +83,32 @@ const Background = (props: {
 				data-id={props.image.id}
 				draggable
 				onDragStart={() => props.setDraggedElement(props.image)}
-			/>
+				onMouseEnter={() => setHovered(true)}
+				onMouseLeave={() => setHovered(false)}
+			>
+				<div
+					style={{
+						position: "relative",
+						width: "100%",
+						height: "100%",
+					}}
+				>
+					{(isInQueue || hovered) && (
+						<Checkbox
+							size="xs"
+							style={{
+								position: "absolute",
+								top: "7px",
+								right: "7px",
+							}}
+							checked={isInQueue}
+							onChange={(event) =>
+								setQueueStatus(event.target.checked)
+							}
+						/>
+					)}
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/src/components/settings/playlist_settings/filetypes/background.tsx
+++ b/src/components/settings/playlist_settings/filetypes/background.tsx
@@ -1,9 +1,10 @@
-import styles from "./background.module.css";
-import globalstyles from "../playlistsettingscomponent.module.css";
-import { IImage, metaDb } from "../../../../utils/db";
 import { Checkbox } from "@mantine/core";
-import { useEffect, useState } from "react";
 import { showNotification } from "@mantine/notifications";
+import { useEffect, useRef, useState } from "react";
+import { IImage, metaDb } from "../../../../utils/db";
+import EventHandler from "../../../../utils/eventhandler";
+import globalstyles from "../playlistsettingscomponent.module.css";
+import styles from "./background.module.css";
 
 const Background = (props: {
 	image: IImage;
@@ -13,6 +14,7 @@ const Background = (props: {
 }) => {
 	const [isInQueue, setIsInQueue] = useState<boolean>(false);
 	const [hovered, setHovered] = useState<boolean>(false);
+	const checkboxHover = useRef<boolean>();
 
 	useEffect(() => {
 		metaDb.getMeta("selected_queue").then((value: any) => {
@@ -22,6 +24,23 @@ const Background = (props: {
 					.then(setIsInQueue);
 			}
 		});
+
+		EventHandler.on(
+			"queue.removeImage",
+			`image-filetype-#${props.image.id}`,
+			(data: { value: number }) => {
+				if (data.value === props.image.id) {
+					setIsInQueue(false);
+				}
+			}
+		);
+
+		return () => {
+			EventHandler.off(
+				"queue.removeImage",
+				`image-filetype-#${props.image.id}`
+			);
+		};
 	}, [props.image]);
 
 	const setQueueStatus = (addToQueue: boolean) => {
@@ -59,6 +78,7 @@ const Background = (props: {
 		<div
 			className={`${globalstyles.element_container} ${styles.image_container}`}
 			data-context-filetype="image"
+			data-id={props.image.id}
 			style={{
 				border: props.selected
 					? "3px solid var(--mantine-color-blue-5)"
@@ -85,6 +105,11 @@ const Background = (props: {
 				onDragStart={() => props.setDraggedElement(props.image)}
 				onMouseEnter={() => setHovered(true)}
 				onMouseLeave={() => setHovered(false)}
+				onClick={() => {
+					if (!checkboxHover.current) {
+						metaDb.setMeta("selected_image", props.image.id);
+					}
+				}}
 			>
 				<div
 					style={{
@@ -92,14 +117,19 @@ const Background = (props: {
 						width: "100%",
 						height: "100%",
 					}}
+					data-context-filetype="image"
+					data-id={props.image.id}
 				>
 					{(isInQueue || hovered) && (
 						<Checkbox
+							onMouseEnter={() => (checkboxHover.current = true)}
+							onMouseLeave={() => (checkboxHover.current = false)}
 							size="xs"
 							style={{
 								position: "absolute",
 								top: "7px",
 								right: "7px",
+								zIndex: 100,
 							}}
 							checked={isInQueue}
 							onChange={(event) =>

--- a/src/components/settings/playlist_settings/queue/Queue.tsx
+++ b/src/components/settings/playlist_settings/queue/Queue.tsx
@@ -1,5 +1,182 @@
+import {
+	ActionIcon,
+	Button,
+	Drawer,
+	Group,
+	Space,
+	Stack,
+	Text,
+} from "@mantine/core";
+import AddIcon from "@mui/icons-material/Add";
+import CheckIcon from "@mui/icons-material/Check";
+import ClearIcon from "@mui/icons-material/Clear";
+import FolderOpen from "@mui/icons-material/FolderOpen";
+import Settings from "@mui/icons-material/Settings";
+import { useLiveQuery } from "dexie-react-hooks";
+import { useState } from "react";
+import { IImage, IQueue, metaDb, useMeta } from "../../../../utils/db";
+import styles from "./queue.module.css";
+import MinimizeIcon from "@mui/icons-material/Minimize";
+import FullscreenIcon from "@mui/icons-material/Fullscreen";
+
+const QueueList = () => {
+	const queues = useLiveQuery(() => metaDb.queues.toArray() || []);
+	const currentQid = useMeta("selected_queue");
+
+	return (
+		<>
+			<Space h="md" />
+			<div
+				style={{
+					display: "flex",
+					justifyContent: "flex-end",
+				}}
+			>
+				<Button
+					leftIcon={<AddIcon />}
+					onClick={() => metaDb.addQueue()}
+				>
+					Create Queue
+				</Button>
+			</div>
+			<Space h="lg" />
+			<Stack spacing="xs">
+				{queues &&
+					(queues as unknown as IQueue[]).map((queue: IQueue) => (
+						<div
+							className={styles.list__queue}
+							style={{
+								border:
+									currentQid === queue.id
+										? "1px solid var(--mantine-color-blue-5)"
+										: "none",
+							}}
+							key={queue.id}
+							onClick={() =>
+								metaDb.setMeta("selected_queue", queue.id)
+							}
+						>
+							<span>{queue.name}</span>
+							<Group position="right" spacing="xs">
+								<ActionIcon>
+									{/* TOOD: Open a modal for editing queue information */}
+									<Settings />
+								</ActionIcon>
+								<ActionIcon>
+									<ClearIcon />
+								</ActionIcon>
+							</Group>
+						</div>
+					))}
+			</Stack>
+		</>
+	);
+};
+
 const Queue = () => {
-	return null;
+	const qid = useMeta("selected_queue");
+	const currentQueue = useLiveQuery(async () => {
+		const currentQueue = await metaDb.meta.get("selected_queue");
+
+		if (currentQueue !== undefined && currentQueue.value !== null) {
+			return await metaDb.queues.get(currentQueue.value);
+		}
+	});
+
+	const images = useLiveQuery(async () => {
+		const currentQueue = await metaDb.meta.get("selected_queue");
+
+		if (currentQueue !== undefined && currentQueue.value !== null) {
+			const queue = await metaDb.queues.get(currentQueue.value);
+
+			if (queue !== undefined) {
+				return (await metaDb.images.bulkGet(queue.images)) || [];
+			}
+		}
+
+		return [];
+	});
+
+	const [queueManagerOpened, setQueueManagerOpened] =
+		useState<boolean>(false);
+	const [minimized, setMinimized] = useState<boolean>(false);
+
+	return (
+		<>
+			<div
+				className={styles.container}
+				style={{
+					padding: minimized ? "3px 1em" : undefined,
+				}}
+			>
+				<header
+					className={styles.header}
+					style={{
+						marginBottom: minimized ? "0px" : undefined,
+					}}
+				>
+					<span>
+						{currentQueue !== undefined
+							? currentQueue.name
+							: "Queue"}
+					</span>
+					<div className={styles.toolbar}>
+						<ActionIcon onClick={() => setQueueManagerOpened(true)}>
+							<FolderOpen />
+						</ActionIcon>
+						{minimized ? (
+							<ActionIcon onClick={() => setMinimized(false)}>
+								<FullscreenIcon />
+							</ActionIcon>
+						) : (
+							<ActionIcon onClick={() => setMinimized(true)}>
+								<MinimizeIcon />
+							</ActionIcon>
+						)}
+					</div>
+				</header>
+				{!minimized && (
+					<main className={styles.main}>
+						{qid === undefined || qid === null ? (
+							<Text color="dimmed">No queue selected.</Text>
+						) : images !== undefined && images.length > 0 ? (
+							(images as unknown as IImage[]).map(
+								(image: IImage, index: number) => {
+									return (
+										<div
+											className={styles.image}
+											key={index}
+										>
+											<img
+												src={image.url}
+												alt={"Queue"}
+											/>
+										</div>
+									);
+								}
+							)
+						) : (
+							<Text color="dimmed">
+								The queue doesn't contain any images
+							</Text>
+						)}
+					</main>
+				)}
+			</div>
+
+			{/* Queue list drawer */}
+			<Drawer
+				opened={queueManagerOpened}
+				position="right"
+				onClose={() => setQueueManagerOpened(false)}
+				title="Manage your image queues"
+				padding="xl"
+				size="xl"
+			>
+				<QueueList />
+			</Drawer>
+		</>
+	);
 };
 
 export default Queue;

--- a/src/components/settings/playlist_settings/queue/Queue.tsx
+++ b/src/components/settings/playlist_settings/queue/Queue.tsx
@@ -18,6 +18,7 @@ import { IImage, IQueue, metaDb, useMeta } from "../../../../utils/db";
 import styles from "./queue.module.css";
 import MinimizeIcon from "@mui/icons-material/Minimize";
 import FullscreenIcon from "@mui/icons-material/Fullscreen";
+import EventHandler from "../../../../utils/eventhandler";
 
 const QueueList = () => {
 	const queues = useLiveQuery(() => metaDb.queues.toArray() || []);
@@ -75,6 +76,8 @@ const QueueList = () => {
 
 const Queue = () => {
 	const qid = useMeta("selected_queue");
+	const cImage = useMeta("selected_image");
+
 	const currentQueue = useLiveQuery(async () => {
 		const currentQueue = await metaDb.meta.get("selected_queue");
 
@@ -146,11 +149,48 @@ const Queue = () => {
 										<div
 											className={styles.image}
 											key={index}
+											style={{
+												border:
+													cImage === image.id
+														? "3px solid var(--mantine-color-blue-5)"
+														: undefined,
+											}}
 										>
 											<img
 												src={image.url}
 												alt={"Queue"}
+												onClick={() =>
+													metaDb.setMeta(
+														"selected_image",
+														image.id
+													)
+												}
 											/>
+											<ActionIcon
+												className={styles.clear_button}
+												color="red"
+												variant="transparent"
+												onClick={() => {
+													metaDb.removeImageFromQueue(
+														qid,
+														image
+													);
+
+													EventHandler.emit(
+														"queue.removeImage",
+														{ value: image.id }
+													);
+												}}
+											>
+												<ClearIcon
+													sx={{
+														fontSize: "19px",
+													}}
+													className={
+														styles.clear_icon
+													}
+												/>
+											</ActionIcon>
 										</div>
 									);
 								}

--- a/src/components/settings/playlist_settings/queue/Queue.tsx
+++ b/src/components/settings/playlist_settings/queue/Queue.tsx
@@ -1,0 +1,5 @@
+const Queue = () => {
+	return null;
+};
+
+export default Queue;

--- a/src/components/settings/playlist_settings/queue/Queue.tsx
+++ b/src/components/settings/playlist_settings/queue/Queue.tsx
@@ -69,7 +69,7 @@ const Queue = () => {
 				>
 					<span>
 						{currentQueue !== undefined
-							? currentQueue.name
+							? `${currentQueue.name} (${(images || []).length})`
 							: "Queue"}
 					</span>
 					<div className={styles.toolbar}>
@@ -216,7 +216,9 @@ const QueueList = () => {
 								metaDb.setMeta("selected_queue", queue.id)
 							}
 						>
-							<span>{queue.name}</span>
+							<span>
+								{queue.name} ({queue.images.length})
+							</span>
 							<Group position="right" spacing="xs">
 								<ActionIcon
 									onClick={() => {

--- a/src/components/settings/playlist_settings/queue/queue.module.css
+++ b/src/components/settings/playlist_settings/queue/queue.module.css
@@ -1,0 +1,63 @@
+.container {
+	position: absolute;
+	z-index: 30;
+	bottom: 0;
+	left: 0;
+	right: 0;
+	background-color: white;
+	box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
+	padding: 2em 1em;
+}
+
+.header {
+	display: flex;
+	gap: 10px;
+	align-items: center;
+	margin-bottom: 1em;
+}
+
+.header > span {
+	font-size: 23px;
+}
+
+.toolbar {
+	display: flex;
+	align-items: center;
+}
+
+.main {
+	display: flex;
+	gap: 2px;
+	flex-wrap: wrap;
+	/* max two rows */
+	max-height: 100px;
+	overflow-y: auto;
+}
+
+.image {
+	height: 50px;
+	width: 50px;
+	border-radius: 10px;
+	background-color: var(--mantine-color-gray-2);
+}
+
+.image img {
+	height: 100%;
+	width: 100%;
+	border-radius: 3px;
+}
+
+.list__queue {
+	background-color: var(--mantine-color-gray-2);
+	padding: var(--mantine-spacing-sm);
+	border-radius: var(--mantine-radius-sm);
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	cursor: pointer;
+	box-sizing: border-box;
+}
+
+.list__queue:hover {
+	background-color: var(--mantine-color-gray-3);
+}

--- a/src/components/settings/playlist_settings/queue/queue.module.css
+++ b/src/components/settings/playlist_settings/queue/queue.module.css
@@ -30,21 +30,50 @@
 	gap: 2px;
 	flex-wrap: wrap;
 	/* max two rows */
-	max-height: 100px;
+	max-height: 150px;
 	overflow-y: auto;
 }
 
 .image {
-	height: 50px;
-	width: 50px;
-	border-radius: 10px;
+	border-radius: 3px;
+	box-shadow: 3px 3px 3px rgba(0, 0, 0, 0.2);
+	height: 75px;
+	aspect-ratio: 1;
 	background-color: var(--mantine-color-gray-2);
+	overflow: hidden;
+	position: relative;
+	isolation: isolate;
+	box-sizing: border-box;
+}
+
+.image:hover {
+	border: 0.5px solid var(--mantine-color-blue-5);
 }
 
 .image img {
-	height: 100%;
-	width: 100%;
-	border-radius: 3px;
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	height: 120px;
+	aspect-ratio: 1;
+	z-index: 1;
+}
+
+.clear_button {
+	position: absolute;
+	top: -3px;
+	right: -3px;
+	z-index: 2;
+	opacity: 0;
+}
+
+.image:hover .clear_button {
+	opacity: 1;
+}
+
+.clear_button:hover {
+	background-color: rgba(0, 0, 0, 0.2);
 }
 
 .list__queue {

--- a/src/components/settings/settingscomponent.module.css
+++ b/src/components/settings/settingscomponent.module.css
@@ -99,15 +99,15 @@
 .scroller {
 	width: 100%;
 	height: 100%;
-	overflow-y: scroll;
+	overflow-y: auto;
 }
 
 .scroller_content {
 	padding-left: 6px;
-	padding-right: 0px;
+	padding-right: 6px;
 }
 
 /* Settings list */
 .settings_list {
-	padding: 0 2em 3em;
+	padding: 0 20px 3em;
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import { metaDb } from "./utils/db";
 import { addMissing } from "./utils/registry/fixmissing";
 
 metaDb.registerMeta("selected_image", 1);
+metaDb.registerMeta("selected_queue", null);
 metaDb.anyImagesOrInsert(
 	"https://best-extension.extfans.com/theme/wallpapers/pmafipeoccakjnacdojijhgmelhjbk/df23e73165204f223d080cbd0b4bc4.webp",
 	"love! live! drinking"

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -440,6 +440,10 @@ class MetaDatabase extends Dexie {
 
 		return queue.images.includes(image.id);
 	}
+
+	async editQueue(qid: number, values: Omit<Partial<IQueue>, "id">) {
+		return this.queues.update(qid, values);
+	}
 }
 
 export const useMeta = (key: string, mapFunction?: Function): any => {


### PR DESCRIPTION
As to follow the approach taken by WE, this pull rquest introduces image queues. Users are able to create, select and configure queues as well as add images to the selected queue by pressing the checkbox overlaying the images. Those queues will be used to make background switiching easier. It should also be noted that if no queues exists, the value of the current queue is null and thus no image will be switched. But here, the user will still be able to select an image as a background by simply clicking on it.
