### PR TITLE
Redesign of settings page

### DIFF
--- a/src/components/settings/widget_settings/SettingsElement.tsx
+++ b/src/components/settings/widget_settings/SettingsElement.tsx
@@ -1,38 +1,64 @@
-import { Menu, Switch } from "@mantine/core";
+import { Menu, Stack, Switch } from "@mantine/core";
 import { useSetting } from "../../../utils/eventhooks";
 import { Component } from "../../../utils/registry/types";
 import styles from "./settingselement.module.css";
-import SettingsFormItem from "./SettingsFormItem";
+import SettingsFormItem, { SettingsItemLabel } from "./SettingsFormItem";
 import EventHandler from "../../../utils/eventhandler";
 import SettingsIcon from "@mui/icons-material/Settings";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { registry } from "../../../utils/registry/customcomponentregistry";
+import { useEffect, useRef, useState } from "react";
+
+const MAX_HEIGHT = 1200; // about 6 dropdowns
 
 function SettingsElement(props: { data: Component; searchValue: string }) {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const [checked, setChecked] = useSetting(props.data.fullId, "state");
+	const [minimized, setMinimized] = useState<boolean>(false);
+	const contentRef = useRef<HTMLDivElement>();
+	const toolbarHovered = useRef<boolean>(false);
+	const initialHeight = useRef<number>();
+
+	useEffect(() => {
+		if (
+			!minimized &&
+			contentRef.current &&
+			initialHeight.current === null
+		) {
+			initialHeight.current = Math.min(
+				MAX_HEIGHT,
+				contentRef.current.clientHeight
+			);
+		}
+	}, [contentRef, contentRef.current, minimized]);
 
 	return (
 		<div className={`${styles.item} ${!checked ? "disabled" : ""}`}>
-			<div className={styles.title}>
-				<p className={styles.title_text}>
-					{props.data.headerSettings.name}
-				</p>
+			{/* Header */}
+			<div
+				className={styles.title}
+				onClick={() =>
+					toolbarHovered.current === false
+						? setMinimized(!minimized)
+						: void 0
+				}
+			>
+				<SettingsItemLabel
+					className={styles.title_text}
+					name={props.data.headerSettings.name}
+					searchValue={props.searchValue || undefined}
+				/>
+				{/* Toolbar */}
 				<div
 					style={{
 						display: "flex",
 						gap: "7px",
 					}}
+					/* @ts-ignore */
+					onMouseEnter={() => (toolbarHovered.current = true)}
+					onMouseLeave={() => (toolbarHovered.current = false)}
 				>
-					{checked !== undefined ? (
-						<Switch
-							checked={checked}
-							onChange={(e) => {
-								setChecked(e.currentTarget.checked);
-								EventHandler.emit("rerenderAll");
-							}}
-						/>
-					) : null}
+					{/* As deleting is currently the only option, the settings button will only available when the component is deletable */}
 					{props.data.metadata.removeableComponent ? (
 						<Menu shadow="md" width={200} position="left-start">
 							<Menu.Target>
@@ -73,9 +99,38 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 							</Menu.Dropdown>
 						</Menu>
 					) : null}
+					{checked !== undefined ? (
+						<Switch
+							checked={checked}
+							onChange={(e) => {
+								setChecked(e.currentTarget.checked);
+								EventHandler.emit("rerenderAll");
+							}}
+						/>
+					) : null}
 				</div>
 			</div>
-			<div>
+
+			{/* Body */}
+			<Stack
+				spacing="xs"
+				className={`${styles.content} ${
+					minimized ? styles.content__minimized : undefined
+				}`}
+				style={{
+					maxHeight: minimized
+						? undefined
+						: `${initialHeight.current || MAX_HEIGHT}px`,
+					overflowY: minimized
+						? "hidden"
+						: contentRef.current &&
+						  contentRef.current?.clientHeight >= MAX_HEIGHT
+						? "auto"
+						: undefined,
+				}}
+				/* @ts-ignore */
+				ref={contentRef}
+			>
 				{props.data.contentSettings?.map(
 					(componentSetting, index: number) => {
 						if (props.searchValue == null) {
@@ -103,12 +158,25 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 									key={index}
 								/>
 							);
+						} else if (
+							props.data.headerSettings.name
+								.toLowerCase()
+								.includes(props.searchValue.toLowerCase())
+						) {
+							return (
+								<SettingsFormItem
+									componentSetting={componentSetting}
+									componentId={props.data.fullId}
+									disabled={checked === false}
+									key={index}
+								/>
+							);
 						}
 
 						return null;
 					}
 				)}
-			</div>
+			</Stack>
 		</div>
 	);
 }

--- a/src/components/settings/widget_settings/SettingsFormItem.tsx
+++ b/src/components/settings/widget_settings/SettingsFormItem.tsx
@@ -3,68 +3,43 @@ import { useSetting } from "../../../utils/eventhooks";
 import { Setting } from "../../../utils/registry/types";
 import styles from "./settingsformitem.module.css";
 
-function SettingsItemLabel(props: { name: string; searchValue?: string }) {
+export const SettingsItemLabel = (props: {
+	name: string;
+	searchValue?: string;
+	className?: string;
+}) => {
 	if (props.searchValue === undefined) {
-		return <p className={styles.item_label}>{props.name}</p>;
+		return <p className={props.className}>{props.name}</p>;
 	} else {
-		let recordLength = 0;
-		let recordStart = 0;
-		let start = 0;
-		let count = 0;
+		if (
+			props.name.toLowerCase().includes(props.searchValue.toLowerCase())
+		) {
+			const start = props.name
+				.toLowerCase()
+				.indexOf(props.searchValue.toLowerCase());
+			const length = props.searchValue.length;
 
-		for (let i = 0; i < props.searchValue.length; i++) {
-			if (
-				props.name
-					.toLowerCase()
-					.includes(
-						props.searchValue.toLowerCase().substring(0, i + 1)
-					)
-			) {
-				if (count === 0) {
-					start = props.name
-						.toLowerCase()
-						.indexOf(
-							props.searchValue.toLowerCase().substring(0, i + 1)
-						);
-				}
-
-				count++;
-
-				if (count > recordLength) {
-					recordLength = count;
-					recordStart = start;
-				}
-			} else {
-				count = 0;
-				start = 0;
-			}
-		}
-
-		if (recordLength > 0) {
 			return (
 				<p
-					className={styles.item_label}
+					className={props.className}
 					style={{ fontFamily: "inherit" }}
 				>
-					{props.name.substring(0, recordStart)}
+					{props.name.substring(0, start)}
 					<span
 						style={{
 							fontFamily: "inherit",
-							backgroundColor: "#9AB0303D",
+							backgroundColor: "var(--mantine-color-yellow-5)",
 						}}
 					>
-						{props.name.substring(
-							recordStart,
-							recordStart + recordLength
-						)}
+						{props.name.substring(start, start + length)}
 					</span>
-					{props.name.substring(recordStart + recordLength)}
+					{props.name.substring(start + length)}
 				</p>
 			);
 		} else {
 			return (
 				<p
-					className={styles.item_label}
+					className={props.className}
 					style={{ fontFamily: "inherit" }}
 				>
 					{props.name}
@@ -72,7 +47,7 @@ function SettingsItemLabel(props: { name: string; searchValue?: string }) {
 			);
 		}
 	}
-}
+};
 
 function SettingsFormItem(props: {
 	componentSetting: Setting;
@@ -91,6 +66,9 @@ function SettingsFormItem(props: {
 				<SettingsItemLabel
 					name={props.componentSetting.name}
 					searchValue={props.searchValue}
+					className={`${styles.item_label} ${
+						props.disabled ? styles.item_label__disabled : undefined
+					}`}
 				/>
 				<div>
 					<NativeSelect
@@ -105,6 +83,7 @@ function SettingsFormItem(props: {
 						}}
 						variant="filled"
 						disabled={props.disabled}
+						classNames={{ input: styles.element }}
 					/>
 				</div>
 			</div>
@@ -115,6 +94,9 @@ function SettingsFormItem(props: {
 				<SettingsItemLabel
 					name={props.componentSetting.name}
 					searchValue={props.searchValue}
+					className={`${styles.item_label} ${
+						props.disabled ? styles.item_label__disabled : undefined
+					}`}
 				/>
 				<div>
 					{props.componentSetting.hidden ? (
@@ -124,6 +106,11 @@ function SettingsFormItem(props: {
 							value={data}
 							variant="filled"
 							disabled={props.disabled}
+							classNames={{
+								input: styles.element,
+								icon: styles.element,
+								rightSection: styles.element,
+							}}
 						/>
 					) : (
 						<TextInput
@@ -132,6 +119,11 @@ function SettingsFormItem(props: {
 							value={data}
 							variant="filled"
 							disabled={props.disabled}
+							classNames={{
+								input: styles.element,
+								icon: styles.element,
+								rightSection: styles.element,
+							}}
 						/>
 					)}
 				</div>

--- a/src/components/settings/widget_settings/WidgetSettingsComponent.tsx
+++ b/src/components/settings/widget_settings/WidgetSettingsComponent.tsx
@@ -1,18 +1,6 @@
 // @ts-nocheck
-import {
-	Button,
-	Group,
-	Menu,
-	Modal,
-	Stack,
-	Text,
-	Textarea,
-} from "@mantine/core";
-import { useForm } from "@mantine/form";
-import { showNotification } from "@mantine/notifications";
-import React, { useEffect, useState } from "react";
-import ReactJson from "react-json-view";
-import { widgetsDb } from "../../../utils/db";
+import { Button, Menu, Stack } from "@mantine/core";
+import React, { useState } from "react";
 import EventHandler from "../../../utils/eventhandler";
 import { registry } from "../../../utils/registry/customcomponentregistry";
 import { Component, KnownComponent } from "../../../utils/registry/types";
@@ -43,164 +31,9 @@ const containsString = (string: string, component: Component) => {
 
 const WidgetSettingsComponent = (props: { bodyRef: any }) => {
 	const [searchbarValue, setSearchbarValue] = useState("");
-	const [exportModalState, setExportModalState] = useState(false);
-	const [importModalState, setImportModalState] = useState(false);
-	const [jsonData, setJsonData] = useState({});
-
-	useEffect(() => {
-		if (exportModalState === true) {
-			(async () => {
-				setJsonData(await widgetsDb.toJson());
-			})();
-		}
-	}, [exportModalState]);
-
-	const importSettingsForm = useForm({
-		initialValues: {
-			json: "",
-		},
-		validate: {
-			json: (value) => {
-				try {
-					JSON.parse(value);
-				} catch (e) {
-					return "Invalid JSON";
-				}
-				return null;
-			},
-		},
-	});
 
 	return (
 		<React.Fragment>
-			{/* Export Modal */}
-			<Modal
-				opened={exportModalState}
-				onClose={() => setExportModalState(false)}
-				title="Export Settings"
-			>
-				<Stack>
-					<Text color="dimmed">
-						The json data below is being stored in your IndexedDB.
-						MyAnimeTab does not collect any data and sends it to any
-						server, thus everything is saved on the client.
-					</Text>
-					<ReactJson
-						src={jsonData}
-						style={{
-							border: "1px solid rgba(0,0,0,0.2)",
-							borderRadius: "14px",
-							padding: "10px",
-							marginTop: "10px",
-						}}
-						name={false}
-						collapsed={true}
-						collapseStringsAfterLength={65}
-						displayDataTypes={false}
-						enableClipboard={false}
-					/>
-					<Group position="right">
-						<Button
-							color="green"
-							onClick={() => {
-								navigator.clipboard.writeText(
-									JSON.stringify(jsonData)
-								);
-
-								showNotification({
-									title: "Data copied to clipboard!",
-								});
-							}}
-						>
-							Copy
-						</Button>
-						<Button onClick={() => setExportModalState(false)}>
-							Close
-						</Button>
-					</Group>
-				</Stack>
-			</Modal>
-
-			{/* Import Modal */}
-			<Modal
-				opened={importModalState}
-				onClose={() => setImportModalState(false)}
-				title="Import Settings"
-			>
-				<form
-					onSubmit={importSettingsForm.onSubmit(
-						(
-							values: { json: string },
-							event: React.FormEvent<HTMLFormElement>
-						) => {
-							showNotification({
-								color: "yellow",
-								title: "Trying to load json data...",
-							});
-
-							setTimeout(() => {
-								try {
-									widgetsDb.fromJSON(JSON.parse(values.json));
-								} catch (e) {
-									console.error(e);
-
-									showNotification({
-										color: "red",
-										title: "An error occured while loading data!",
-										message:
-											"For more details, take a look at the console. If you need any help, reach out to us at the support discord server!",
-									});
-
-									return;
-								}
-
-								showNotification({
-									color: "green",
-									title: "Successfully loaded json data!",
-									message:
-										"Page will be reloaded in a moment to update the existing data.",
-								});
-
-								setTimeout(
-									() => window.location.reload(),
-									3000
-								);
-							}, 1000);
-						}
-					)}
-				>
-					<Stack>
-						<Text color="dimmed">
-							It may not always be possible that you are able to
-							import data as the structure differs from version to
-							version. If you need any help, feel free to ask on
-							the{" "}
-							<a href="https://aridevelopment.de/dc">
-								Support Discord Server
-							</a>
-						</Text>
-						<Textarea
-							placeholder="Enter valid json"
-							label="Enter the settings data below"
-							withAsterisk
-							{...importSettingsForm.getInputProps("json", {
-								type: "input",
-							})}
-						/>
-						<Group position="right">
-							<Button
-								variant="outline"
-								color="gray"
-								onClick={() => setImportModalState(false)}
-							>
-								Close
-							</Button>
-							<Button type="submit">Submit</Button>
-						</Group>
-					</Stack>
-				</form>
-			</Modal>
-
 			{/* Widget Settings */}
 			<div className={styles.toolbar}>
 				<input
@@ -247,37 +80,31 @@ const WidgetSettingsComponent = (props: { bodyRef: any }) => {
 					</Menu.Dropdown>
 				</Menu>
 			</div>
-			{registry.installedComponents.map((component: Component) => {
-				if (searchbarValue.trim() === "") {
-					return (
-						<SettingsElement
-							data={component}
-							key={component.fullId}
-							searchValue={null}
-						/>
-					);
-				}
+			<Stack>
+				{registry.installedComponents.map((component: Component) => {
+					if (searchbarValue.trim() === "") {
+						return (
+							<SettingsElement
+								data={component}
+								key={component.fullId}
+								searchValue={null}
+							/>
+						);
+					}
 
-				if (containsString(searchbarValue, component)) {
-					return (
-						<SettingsElement
-							data={component}
-							key={component.fullId}
-							searchValue={searchbarValue}
-						/>
-					);
-				}
+					if (containsString(searchbarValue, component)) {
+						return (
+							<SettingsElement
+								data={component}
+								key={component.fullId}
+								searchValue={searchbarValue}
+							/>
+						);
+					}
 
-				return null;
-			})}
-			<div className={styles.control_group}>
-				<Button onClick={() => setImportModalState(true)} color="green">
-					Import
-				</Button>
-				<Button onClick={() => setExportModalState(true)} color="blue">
-					Export
-				</Button>
-			</div>
+					return null;
+				})}
+			</Stack>
 			<footer id={styles.footer}>
 				<div className={styles.urls}>
 					<a href="https://github.com/aridevelopment-de/myanimetab">

--- a/src/components/settings/widget_settings/settingselement.module.css
+++ b/src/components/settings/widget_settings/settingselement.module.css
@@ -1,15 +1,16 @@
 .item {
-	margin-bottom: 32px;
 	animation: var(--fadeInAnimation);
-	background-color: rgba(133, 133, 133, 0.05);
+	background-color: var(--mantine-color-gray-2);
 	border-radius: 14px;
-	padding: 1em;
+	overflow: hidden;
 }
 
 .title {
 	display: flex;
 	align-items: center;
-	margin-bottom: 1.5em;
+	background-color: var(--mantine-color-gray-4);
+	padding: 1em;
+	cursor: pointer;
 }
 
 .title_text {
@@ -18,4 +19,23 @@
 	font-size: 20px;
 	color: #2f2f2f;
 	margin: 0;
+	user-select: none;
+}
+
+.content {
+	padding: 1.5em 1em;
+	padding-top: 0;
+	overflow: hidden;
+	opacity: 1;
+	transform: translateX(0%);
+	transition-property: all;
+	transition-duration: 750ms;
+	transition-timing-function: ease;
+}
+
+.content__minimized {
+	max-height: 0 !important;
+	padding: 0;
+	opacity: 0;
+	transform: translateX(-100%);
 }

--- a/src/components/settings/widget_settings/settingsformitem.module.css
+++ b/src/components/settings/widget_settings/settingsformitem.module.css
@@ -1,6 +1,13 @@
 .item_label {
-	color: rgba(74, 74, 74, 0.8);
+	color: var(--mantine-color-gray-7);
 	font-size: 14px;
-	margin-bottom: 6px;
-	transition: opacity 0.2s;
+	transition: all 0.2s;
+}
+
+.item_label__disabled {
+	color: var(--mantine-color-gray-6);
+}
+
+.element {
+	transition: all 0.2s;
 }


### PR DESCRIPTION
- Turning up the contrast by introducing a more grayish theme from mantine. 
- Setting blocks are now collapseable as well. 
- Fixed setting block header not being searchable and added more user-feedback for the search itself. 
- Removed import/export settings as this will get a lot more difficult with indexeddb.

Closes #69 