### PR TITLE
Added eventhooks to reduce load times and improve (future) performance

### DIFF
--- a/src/components/settings/widget_settings/SettingsElement.tsx
+++ b/src/components/settings/widget_settings/SettingsElement.tsx
@@ -1,5 +1,5 @@
 import { Menu, Stack, Switch } from "@mantine/core";
-import { useSetting } from "../../../utils/eventhooks";
+import { useSetting, useWidget } from "../../../utils/eventhooks";
 import { Component } from "../../../utils/registry/types";
 import styles from "./settingselement.module.css";
 import SettingsFormItem, { SettingsItemLabel } from "./SettingsFormItem";
@@ -8,12 +8,13 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { registry } from "../../../utils/registry/customcomponentregistry";
 import { useEffect, useRef, useState } from "react";
+import { widgetsDb } from "../../../utils/db";
 
 const MAX_HEIGHT = 1200; // about 6 dropdowns
 
 function SettingsElement(props: { data: Component; searchValue: string }) {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const [checked, setChecked] = useSetting(props.data.fullId, "state");
+	const widget = useWidget(props.data.fullId);
 	const [minimized, setMinimized] = useState<boolean>(false);
 	const contentRef = useRef<HTMLDivElement>();
 	const toolbarHovered = useRef<boolean>(false);
@@ -33,7 +34,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 	}, [contentRef, contentRef.current, minimized]);
 
 	return (
-		<div className={`${styles.item} ${!checked ? "disabled" : ""}`}>
+		<div className={`${styles.item} ${!widget.state ? "disabled" : ""}`}>
 			{/* Header */}
 			<div
 				className={styles.title}
@@ -99,11 +100,15 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 							</Menu.Dropdown>
 						</Menu>
 					) : null}
-					{checked !== undefined ? (
+					{widget.state !== undefined ? (
 						<Switch
-							checked={checked}
+							checked={widget.state}
 							onChange={(e) => {
-								setChecked(e.currentTarget.checked);
+								widgetsDb.setSetting(
+									props.data.fullId,
+									"state",
+									e.currentTarget.checked
+								);
 								EventHandler.emit("rerenderAll");
 							}}
 						/>
@@ -138,7 +143,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 								<SettingsFormItem
 									componentSetting={componentSetting}
 									componentId={props.data.fullId}
-									disabled={checked === false}
+									disabled={widget.state === false}
 									key={index}
 								/>
 							);
@@ -154,7 +159,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 									componentSetting={componentSetting}
 									componentId={props.data.fullId}
 									searchValue={props.searchValue}
-									disabled={checked === false}
+									disabled={widget.state === false}
 									key={index}
 								/>
 							);
@@ -167,7 +172,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 								<SettingsFormItem
 									componentSetting={componentSetting}
 									componentId={props.data.fullId}
-									disabled={checked === false}
+									disabled={widget.state === false}
 									key={index}
 								/>
 							);

--- a/src/components/settings/widget_settings/SettingsFormItem.tsx
+++ b/src/components/settings/widget_settings/SettingsFormItem.tsx
@@ -1,5 +1,5 @@
 import { NativeSelect, PasswordInput, TextInput } from "@mantine/core";
-import { useSetting } from "../../../utils/eventhooks";
+import { useCachedSetting, useSetting } from "../../../utils/eventhooks";
 import { Setting } from "../../../utils/registry/types";
 import styles from "./settingsformitem.module.css";
 
@@ -55,7 +55,7 @@ function SettingsFormItem(props: {
 	searchValue?: string;
 	disabled: boolean;
 }) {
-	const [data, setData] = useSetting(
+	const [data, setData] = useCachedSetting(
 		props.componentId,
 		props.componentSetting.key
 	);
@@ -78,7 +78,8 @@ function SettingsFormItem(props: {
 							setData(
 								props.componentSetting.displayedValues.indexOf(
 									e.currentTarget.value
-								)
+								),
+								true
 							);
 						}}
 						variant="filled"
@@ -102,7 +103,9 @@ function SettingsFormItem(props: {
 					{props.componentSetting.hidden ? (
 						<PasswordInput
 							placeholder={props.componentSetting.tooltip}
-							onChange={(e) => setData(e.currentTarget.value)}
+							onChange={(e) =>
+								setData(e.currentTarget.value, true)
+							}
 							value={data}
 							variant="filled"
 							disabled={props.disabled}
@@ -115,7 +118,9 @@ function SettingsFormItem(props: {
 					) : (
 						<TextInput
 							placeholder={props.componentSetting.tooltip}
-							onChange={(e) => setData(e.currentTarget.value)}
+							onChange={(e) =>
+								setData(e.currentTarget.value, true)
+							}
 							value={data}
 							variant="filled"
 							disabled={props.disabled}

--- a/src/components/widgets/clock/WidgetComponentClock.tsx
+++ b/src/components/widgets/clock/WidgetComponentClock.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useSetting } from "../../../utils/eventhooks";
+import { useWidget } from "../../../utils/eventhooks";
 import { KnownComponent } from "../../../utils/registry/types";
 import TimeUtils from "../../../utils/timeutils";
 import styles from "./clock.module.css";
@@ -9,11 +9,9 @@ const opacityValues = [1, 0, 0.7, 0.5, 0.3];
 const timeFormatValues = ["24h", "12h"]; // if these values changes,  also change the if conditions
 
 function Clock(props: { blur: boolean; id: string }) {
-	const [position, _] = useSetting(props.id, "position");
-	const [timeFormat, _1] = useSetting(props.id, "time_format");
-	const [autoHideValue, _2] = useSetting(props.id, "auto_hide");
+	const widget = useWidget(props.id);
 	const [currentTime, setCurrentTime] = useState(
-		TimeUtils.convertTimeToClockFormat(new Date(), timeFormat === 1)
+		TimeUtils.convertTimeToClockFormat(new Date(), widget.timeFormat === 1)
 	);
 
 	useEffect(() => {
@@ -21,7 +19,7 @@ function Clock(props: { blur: boolean; id: string }) {
 			let currentDate = new Date();
 			let currentFmtDate = TimeUtils.convertTimeToClockFormat(
 				currentDate,
-				timeFormat === 1
+				widget.timeFormat === 1
 			);
 			let lastFmtDate = currentTime;
 
@@ -34,26 +32,32 @@ function Clock(props: { blur: boolean; id: string }) {
 		}, 10000);
 
 		return () => clearInterval(interval);
-	}, [currentTime, timeFormat]);
+	}, [currentTime, widget.timeFormat]);
 
-	if (position === undefined) return <></>;
+	if (widget.position === undefined) return <></>;
 
 	return (
-		<div className={`${styles.wrapper} ${positionValues[position]}`}>
+		<div className={`${styles.wrapper} ${positionValues[widget.position]}`}>
 			<div
 				className={`${styles.clock} widget`}
 				style={{
-					opacity: props.blur ? opacityValues[autoHideValue] : 1,
+					opacity: props.blur
+						? opacityValues[widget.autoHideValue]
+						: 1,
 				}}
 			>
 				<div>
 					<span
-						id={timeFormat === 0 ? styles.time_12hr : styles.time}
+						id={
+							widget.timeFormat === 0
+								? styles.time_12hr
+								: styles.time
+						}
 					>
 						{" "}
 						{currentTime.time}{" "}
 					</span>
-					{timeFormat === 1 ? (
+					{widget.timeFormat === 1 ? (
 						<span id={styles.period}>{currentTime.timePeriod}</span>
 					) : null}
 				</div>

--- a/src/components/widgets/searchbar/WidgetComponentSearchbar.tsx
+++ b/src/components/widgets/searchbar/WidgetComponentSearchbar.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import SearchIcon from "@mui/icons-material/Search";
 import { useState } from "react";
-import { useSetting } from "../../../utils/eventhooks";
+import { useSetting, useWidget } from "../../../utils/eventhooks";
 import { KnownComponent } from "../../../utils/registry/types";
 import SearchEngine from "../../../utils/searchengine";
 import SuggestionCaller from "../../../utils/searchsuggestioncaller";
@@ -23,25 +23,27 @@ const searchEngines = [
 ];
 
 function SearchBar(props: { blur: boolean; id: string }) {
-	const [position, _1] = useSetting(props.id, "vertical_align");
+	const widget = useWidget(props.id);
 	const [searchEngine, setSearchEngine] = useSetting(
 		props.id,
 		"search_engine"
 	);
-	const [openWith, _2] = useSetting(props.id, "open_with");
-	const [autoHideValue, _3] = useSetting(props.id, "auto_hide");
 	const [modalChooseEngine, setModalChooseEngine] = useState<boolean>(false);
 	const [suggestions, setSuggestions] = useState<Array<string>>([]);
 	const [content, setContent] = useState<string>("");
 
-	if (position === undefined) return <></>;
+	if (widget.vertical_align === undefined) return <></>;
 
 	return (
-		<div className={`${styles.wrapper} ${verticalAlignValues[position]}`}>
+		<div
+			className={`${styles.wrapper} ${
+				verticalAlignValues[widget.vertical_align]
+			}`}
+		>
 			<div
 				className={`${styles.searchbar} widget`}
 				style={{
-					opacity: props.blur ? opacityValues[autoHideValue] : 1,
+					opacity: props.blur ? opacityValues[widget.auto_hide] : 1,
 				}}
 			>
 				<div>
@@ -75,7 +77,7 @@ function SearchBar(props: { blur: boolean; id: string }) {
 								// @ts-ignore
 								e.target.value,
 								searchEngine,
-								openWith
+								widget.open_with
 							);
 						}
 					}}
@@ -112,7 +114,11 @@ function SearchBar(props: { blur: boolean; id: string }) {
 				<SearchIcon
 					className={styles.icon}
 					onClick={() =>
-						SearchEngine.search(content, searchEngine, openWith)
+						SearchEngine.search(
+							content,
+							searchEngine,
+							widget.open_with
+						)
 					}
 				/>
 			</div>

--- a/src/components/widgets/weather/WidgetComponentWeather.tsx
+++ b/src/components/widgets/weather/WidgetComponentWeather.tsx
@@ -1,7 +1,7 @@
 import axios from "axios";
 import { useEffect, useState } from "react";
 import { widgetsDb } from "../../../utils/db";
-import { useSetting } from "../../../utils/eventhooks";
+import { useSetting, useWidget } from "../../../utils/eventhooks";
 import { KnownComponent } from "../../../utils/registry/types";
 import errorstyles from "./error.module.css";
 import ErrorComponent from "./ErrorComponent";
@@ -38,9 +38,7 @@ function LoadingComponent(props: { opacity: number }) {
 }
 
 function WeatherWidget(props: { blur: boolean; id: string }) {
-	const [position, _] = useSetting(props.id, "position");
-	const [unit, _1] = useSetting(props.id, "unit");
-	const [autoHideValue, _2] = useSetting(props.id, "auto_hide");
+	const widget = useWidget(props.id);
 	const [data, setData] = useState({
 		statusCode: -1,
 		fullCityName: "Frankfurt am Main",
@@ -52,7 +50,7 @@ function WeatherWidget(props: { blur: boolean; id: string }) {
 		const retrieveData = async () => {
 			const API_KEY = await widgetsDb.getSetting(props.id, "api_key");
 			const CITY = await widgetsDb.getSetting(props.id, "city");
-			const UNIT = metricValues[unit];
+			const UNIT = metricValues[widget.unit];
 
 			axios
 				.get(
@@ -85,26 +83,26 @@ function WeatherWidget(props: { blur: boolean; id: string }) {
 		retrieveData();
 		const interval = setInterval(retrieveData, refreshRate);
 		return () => clearInterval(interval);
-	}, [unit]);
+	}, [widget, widget.unit]);
 
-	if (position === undefined) return <></>;
+	if (widget.position === undefined) return <></>;
 
 	return (
-		<div className={`${styles.wrapper} ${positionValues[position]}`}>
+		<div className={`${styles.wrapper} ${positionValues[widget.position]}`}>
 			{data.statusCode === 200 ? (
 				<NormalComponent
 					data={data}
-					unit={unit}
-					opacity={props.blur ? opacityValues[autoHideValue] : 1}
+					unit={widget.unit}
+					opacity={props.blur ? opacityValues[widget.auto_hide] : 1}
 				/>
 			) : data.statusCode !== -1 ? (
 				<ErrorComponent
 					status={data.statusCode}
-					opacity={props.blur ? opacityValues[autoHideValue] : 1}
+					opacity={props.blur ? opacityValues[widget.auto_hide] : 1}
 				/>
 			) : (
 				<LoadingComponent
-					opacity={props.blur ? opacityValues[autoHideValue] : 1}
+					opacity={props.blur ? opacityValues[widget.auto_hide] : 1}
 				/>
 			)}
 		</div>

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -2,13 +2,13 @@ import Dexie, { Table } from "dexie";
 import { useEffect, useState } from "react";
 import EventHandler from "./eventhandler";
 
-interface Widget {
+export interface IWidget {
 	id: string; // <type>-<number>
 	settings: any;
 }
 
 class WidgetDatabase extends Dexie {
-	widgets!: Table<Widget>;
+	widgets!: Table<IWidget>;
 
 	constructor() {
 		super("widgets");
@@ -18,11 +18,11 @@ class WidgetDatabase extends Dexie {
 		});
 	}
 
-	async toJson(): Promise<Array<Widget>> {
+	async toJson(): Promise<Array<IWidget>> {
 		return await this.widgets.toArray();
 	}
 
-	async fromJSON(data: Array<Widget>) {
+	async fromJSON(data: Array<IWidget>) {
 		// TODO: Add data validation
 		await this.widgets.clear();
 		await this.widgets.bulkAdd(data);
@@ -63,7 +63,7 @@ class WidgetDatabase extends Dexie {
 
 			const id = `${type}-${firstMissingIdentifier}`;
 
-			const widget: Widget = {
+			const widget: IWidget = {
 				id,
 				settings: settings || {},
 			};
@@ -72,7 +72,7 @@ class WidgetDatabase extends Dexie {
 		});
 	}
 
-	getWidget(id: string): Promise<Widget | undefined> {
+	getWidget(id: string): Promise<IWidget | undefined> {
 		return this.widgets.get(id);
 	}
 
@@ -88,7 +88,7 @@ class WidgetDatabase extends Dexie {
 	}
 
 	async getSetting(id: string, key: string): Promise<any | undefined> {
-		return this.widgets.get(id).then((widget: Widget | undefined) => {
+		return this.widgets.get(id).then((widget: IWidget | undefined) => {
 			if (widget === undefined) {
 				return undefined;
 			}

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -1,31 +1,9 @@
 import { useLiveQuery } from "dexie-react-hooks";
-import md5 from "md5";
 import { useEffect, useState } from "react";
-import { widgetsDb } from "./db";
+import { IWidget, widgetsDb } from "./db";
 import EventHandler from "./eventhandler";
 
-export const useSetting = (
-	id: string,
-	key: string,
-	trigger_function?: Function
-): [any, Function] => {
-	/* const [state, setState] = useState();
-    const changeStatus = (value: any) => widgetsDb.setSetting(id, key, value);
-
-    useEvent(`widget.${id}.${key}`, HashCode.value(id + key + String(trigger_function)), null, (data: any) => {
-        const value = (trigger_function || (() => {}))(data) || data;        
-        setState(value);
-    })
-
-    useEffect(() => {
-        widgetsDb.getSetting(id, key).then((data: any) => {
-            const value = (trigger_function || (() => {}))(data) || data;
-            setState(value);
-        })
-    }, [id, key, trigger_function])
-    
-    return [state, changeStatus]; */
-
+export const useSetting = (id: string, key: string): [any, Function] => {
 	const [state, setState] = useState();
 	const data = useLiveQuery(() =>
 		widgetsDb.widgets.where("id").equals(id).toArray()
@@ -45,6 +23,24 @@ export const useSetting = (
 	}, [data, key]);
 
 	return [state, changeData];
+};
+
+export const useWidget = (id: string): any => {
+	const [state, setState] = useState<IWidget>();
+
+	const data = useLiveQuery(() =>
+		widgetsDb.widgets.where("id").equals(id).toArray()
+	);
+
+	useEffect(() => {
+		if (data !== undefined) {
+			if (data[0] !== undefined) {
+				setState(data[0]);
+			}
+		}
+	}, [data]);
+
+	return state;
 };
 
 export const useEvent = (
@@ -70,51 +66,3 @@ export const useEvent = (
 
 	return [state, changeEvent];
 };
-
-/**
- * Javascript HashCode v1.0.0
- * This function returns a hash code (MD5) based on the argument object.
- * http://pmav.eu/stuff/javascript-hash-code
- *
- * Example:
- *  var s = "my String";
- *  alert(HashCode.value(s));
- *
- * pmav, 2010
- */
-var HashCode = (function () {
-	var serialize = function (object: any) {
-		// Private
-		var type,
-			serializedCode = "";
-
-		type = typeof object;
-
-		if (type === "object") {
-			var element;
-
-			for (element in object) {
-				serializedCode +=
-					"[" +
-					type +
-					":" +
-					element +
-					serialize(object[element]) +
-					"]";
-			}
-		} else if (type === "function") {
-			serializedCode += "[" + type + ":" + object.toString() + "]";
-		} else {
-			serializedCode += "[" + type + ":" + object + "]";
-		}
-
-		return serializedCode.replace(/\s/g, "");
-	};
-
-	// Public, API
-	return {
-		value: function (object: any) {
-			return md5(serialize(object));
-		},
-	};
-})();

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -47,7 +47,7 @@ export const useCachedSetting = (id: string, key: string): [any, Function] => {
 				}
 			});
 		}
-	}, [id, key, SETTINGS_CACHE]);
+	}, [id, key, SETTINGS_CACHE[id]]);
 
 	return [state, changeData];
 };

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -1,6 +1,6 @@
 import { useLiveQuery } from "dexie-react-hooks";
 import { useEffect, useState } from "react";
-import { IWidget, widgetsDb } from "./db";
+import { widgetsDb } from "./db";
 import EventHandler from "./eventhandler";
 
 let SETTINGS_CACHE: { [key: string]: { [key: string]: any } } = {};

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -1,7 +1,56 @@
 import { useLiveQuery } from "dexie-react-hooks";
 import { useEffect, useState } from "react";
-import { widgetsDb } from "./db";
+import { IWidget, widgetsDb } from "./db";
 import EventHandler from "./eventhandler";
+
+let SETTINGS_CACHE: { [key: string]: { [key: string]: any } } = {};
+
+export const useCachedSetting = (id: string, key: string): [any, Function] => {
+	const [state, setState] = useState(
+		SETTINGS_CACHE[id] !== undefined &&
+			SETTINGS_CACHE[id][key] !== undefined
+			? SETTINGS_CACHE[id][key]
+			: null
+	);
+
+	const changeData = (newValue: any, update_database?: boolean) => {
+		setState(newValue);
+
+		if (SETTINGS_CACHE[id] === undefined) {
+			SETTINGS_CACHE[id] = {};
+		}
+
+		SETTINGS_CACHE[id][key] = newValue;
+		SETTINGS_CACHE = { ...SETTINGS_CACHE };
+
+		if (update_database) {
+			widgetsDb.setSetting(id, key, newValue);
+		}
+	};
+
+	useEffect(() => {
+		if (SETTINGS_CACHE[id] !== undefined) {
+			if (SETTINGS_CACHE[id][key] !== undefined) {
+				setState(SETTINGS_CACHE[id][key]);
+				return;
+			} else {
+				widgetsDb.getSetting(id, key).then((value) => {
+					if (value) {
+						changeData(value, false);
+					}
+				});
+			}
+		} else {
+			widgetsDb.getSetting(id, key).then((value) => {
+				if (value) {
+					changeData(value, false);
+				}
+			});
+		}
+	}, [id, key, SETTINGS_CACHE]);
+
+	return [state, changeData];
+};
 
 export const useSetting = (id: string, key: string): [any, Function] => {
 	const [state, setState] = useState();

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -1,6 +1,6 @@
 import { useLiveQuery } from "dexie-react-hooks";
 import { useEffect, useState } from "react";
-import { IWidget, widgetsDb } from "./db";
+import { widgetsDb } from "./db";
 import EventHandler from "./eventhandler";
 
 export const useSetting = (id: string, key: string): [any, Function] => {
@@ -25,8 +25,15 @@ export const useSetting = (id: string, key: string): [any, Function] => {
 	return [state, changeData];
 };
 
+const EmptyElement = new Proxy(
+	{},
+	{
+		get: (obj, prop) => undefined,
+	}
+);
+
 export const useWidget = (id: string): any => {
-	const [state, setState] = useState<{ [key: string]: string }>();
+	const [state, setState] = useState<{ [key: string]: string }>(EmptyElement);
 
 	const data = useLiveQuery(() =>
 		widgetsDb.widgets.where("id").equals(id).toArray()

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -26,7 +26,7 @@ export const useSetting = (id: string, key: string): [any, Function] => {
 };
 
 export const useWidget = (id: string): any => {
-	const [state, setState] = useState<IWidget>();
+	const [state, setState] = useState<{ [key: string]: string }>();
 
 	const data = useLiveQuery(() =>
 		widgetsDb.widgets.where("id").equals(id).toArray()
@@ -35,7 +35,7 @@ export const useWidget = (id: string): any => {
 	useEffect(() => {
 		if (data !== undefined) {
 			if (data[0] !== undefined) {
-				setState(data[0]);
+				setState(data[0].settings);
 			}
 		}
 	}, [data]);


### PR DESCRIPTION
This pull request introduces two new eventhooks:
- useWidget
- useCachedSetting

`useWidget` fetches the whole widget settings object instead. This reduces the amount of database queries being made by dexie as dexie doesn't implemented caches in our version of dexiejs
`useCachedSetting` fetches the setting and stores it in a global dictionary. Whenever it pulls the value again, a lookup in the global dictionary is performed first and if found being used. If not, the value will be loaded from indexeddb via dexie

Closes #86 