### PR TITLE
Fixed current_image's value not being set when switching background

### DIFF
--- a/src/components/BackgroundScheduler.tsx
+++ b/src/components/BackgroundScheduler.tsx
@@ -22,7 +22,7 @@ const BackgroundScheduler = () => {
 				await widgetsDb.getSetting("wallpaper-0", "playlist_order")
 			];
 
-		let nextImageId = null;
+		let nextImageId = undefined;
 
 		switch (playlistOrder) {
 			case "Ordered":
@@ -40,7 +40,10 @@ const BackgroundScheduler = () => {
 				return;
 		}
 
-		metaDb.setMeta("selected_image", nextImageId);
+		// if the queue is empty, do nothing
+		if (nextImageId !== undefined) {
+			metaDb.setMeta("selected_image", nextImageId);
+		}
 	};
 
 	/* Wallpaer should switch on page visit */

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -218,8 +218,10 @@ class MetaDatabase extends Dexie {
 	}
 
 	setMeta(name: string, value: any) {
-		this.meta.update(name, { value: value });
-		this.emitOnMetaChange(name, value);
+		if (value !== undefined) {
+			this.meta.update(name, { value: value });
+			this.emitOnMetaChange(name, value);
+		}
 	}
 
 	async registerMeta(name: string, value: any): Promise<boolean> {


### PR DESCRIPTION
Fixes and Closes #111 
Essentially when undefined was being passed to `setMeta`, the value wasn't even set resulting in an error in the background component. The whole thing happend to the selected_image field