### PR TITLE
Changed string event names to a general enum

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import Background from "./BackgroundComponent";
 import SettingsComponent from "./components/settings/SettingsComponent";
 import { widgetsDb } from "./utils/db";
-import EventHandler from "./utils/eventhandler";
+import EventHandler, { EventType } from "./utils/eventhandler";
 import { Component, registry } from "./utils/registry/customcomponentregistry";
 import { MantineProvider } from "@mantine/core";
 import { ModalsProvider } from "@mantine/modals";
@@ -46,7 +46,7 @@ class App extends React.Component {
 			});
 		});
 
-		EventHandler.on("rerenderAll", "app", () => {
+		EventHandler.on(EventType.RERENDER_ALL, "app", () => {
 			setTimeout(() => {
 				registry.loadInstalledComponents(() =>
 					filterEnabledComponents(registry.installedComponents)
@@ -56,7 +56,7 @@ class App extends React.Component {
 	}
 
 	componentWillUnmount(): void {
-		EventHandler.off("rerenderAll", "app");
+		EventHandler.off(EventType.RERENDER_ALL, "app");
 	}
 
 	render() {

--- a/src/components/BackgroundScheduler.tsx
+++ b/src/components/BackgroundScheduler.tsx
@@ -1,6 +1,7 @@
 import { metaDb, widgetsDb } from "../utils/db";
 import { useSetting, useEvent } from "../utils/eventhooks";
 import { useEffect, useState } from "react";
+import { EventType } from "../utils/eventhandler";
 
 const ORDER_VALUES = ["Ordered", "Shuffled"];
 const SWITCH_VALUES = [null, 10, 60, 120, 300, 600, 1800, 3600];
@@ -46,7 +47,7 @@ const BackgroundScheduler = () => {
 		}
 	};
 
-	useEvent("skip_image", "background-scheduler", null, nextBackground);
+	useEvent(EventType.SKIP_IMAGE, "background-scheduler", null, nextBackground);
 
 	/* Wallpaer should switch on page visit */
 	useEffect(() => {

--- a/src/components/settings/SettingsComponent.tsx
+++ b/src/components/settings/SettingsComponent.tsx
@@ -1,5 +1,6 @@
 import CloseIcon from "@mui/icons-material/Close";
 import { useState, useRef } from "react";
+import { EventType } from "../../utils/eventhandler";
 import { useEvent } from "../../utils/eventhooks";
 import PlaylistSettingsComponent from "./playlist_settings/PlaylistSettingsComponent";
 import styles from "./settingscomponent.module.css";
@@ -15,7 +16,7 @@ const pages = {
 
 function SettingsComponent(_props: any) {
 	const [opened, setOpened] = useEvent(
-		"settings_window_state",
+		EventType.SETTINGS_WINDOW_STATE,
 		"settings_component",
 		false,
 		(data: { opened: boolean }) => data.opened

--- a/src/components/settings/playlist_settings/filetypes/background.tsx
+++ b/src/components/settings/playlist_settings/filetypes/background.tsx
@@ -2,7 +2,7 @@ import { Checkbox } from "@mantine/core";
 import { showNotification } from "@mantine/notifications";
 import { useEffect, useRef, useState } from "react";
 import { IImage, metaDb, useMeta } from "../../../../utils/db";
-import EventHandler from "../../../../utils/eventhandler";
+import EventHandler, { EventType } from "../../../../utils/eventhandler";
 import globalstyles from "../playlistsettingscomponent.module.css";
 import styles from "./background.module.css";
 
@@ -33,7 +33,7 @@ const Background = (props: {
 		});
 
 		EventHandler.on(
-			"queue.removeImage",
+			EventType.QUEUE_REMOVE_IMAGE,
 			`image-filetype-#${props.image.id}`,
 			(data: { value: number }) => {
 				if (data.value === props.image.id) {
@@ -44,7 +44,7 @@ const Background = (props: {
 
 		return () => {
 			EventHandler.off(
-				"queue.removeImage",
+				EventType.QUEUE_REMOVE_IMAGE,
 				`image-filetype-#${props.image.id}`
 			);
 		};

--- a/src/components/settings/playlist_settings/queue/Queue.tsx
+++ b/src/components/settings/playlist_settings/queue/Queue.tsx
@@ -18,7 +18,7 @@ import Settings from "@mui/icons-material/Settings";
 import { useLiveQuery } from "dexie-react-hooks";
 import { useRef, useState } from "react";
 import { IImage, IQueue, metaDb, useMeta } from "../../../../utils/db";
-import EventHandler from "../../../../utils/eventhandler";
+import EventHandler, { EventType } from "../../../../utils/eventhandler";
 import styles from "./queue.module.css";
 import DownloadIcon from "@mui/icons-material/Download";
 import { downloadContent } from "../../../../utils/browserutils";
@@ -148,7 +148,7 @@ const Queue = () => {
 													);
 
 													EventHandler.emit(
-														"queue.removeImage",
+														EventType.QUEUE_REMOVE_IMAGE,
 														{ value: image.id }
 													);
 												}}

--- a/src/components/settings/widget_settings/SettingsElement.tsx
+++ b/src/components/settings/widget_settings/SettingsElement.tsx
@@ -3,7 +3,7 @@ import { useSetting, useWidget } from "../../../utils/eventhooks";
 import { Component } from "../../../utils/registry/types";
 import styles from "./settingselement.module.css";
 import SettingsFormItem, { SettingsItemLabel } from "./SettingsFormItem";
-import EventHandler from "../../../utils/eventhandler";
+import EventHandler, { EventType } from "../../../utils/eventhandler";
 import SettingsIcon from "@mui/icons-material/Settings";
 import DeleteIcon from "@mui/icons-material/Delete";
 import { registry } from "../../../utils/registry/customcomponentregistry";
@@ -78,7 +78,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 									}
 									onClick={() => {
 										EventHandler.emit(
-											"settings_window_state",
+											EventType.SETTINGS_WINDOW_STATE,
 											{
 												opened: false,
 											}
@@ -89,7 +89,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 										setTimeout(
 											() =>
 												EventHandler.emit(
-													"rerenderAll"
+													EventType.RERENDER_ALL
 												),
 											50
 										);
@@ -109,7 +109,7 @@ function SettingsElement(props: { data: Component; searchValue: string }) {
 									"state",
 									e.currentTarget.checked
 								);
-								EventHandler.emit("rerenderAll");
+								EventHandler.emit(EventType.RERENDER_ALL);
 							}}
 						/>
 					) : null}

--- a/src/components/settings/widget_settings/WidgetSettingsComponent.tsx
+++ b/src/components/settings/widget_settings/WidgetSettingsComponent.tsx
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { Button, Menu, Stack } from "@mantine/core";
 import React, { useState } from "react";
-import EventHandler from "../../../utils/eventhandler";
+import EventHandler, { EventType } from "../../../utils/eventhandler";
 import { registry } from "../../../utils/registry/customcomponentregistry";
 import { Component, KnownComponent } from "../../../utils/registry/types";
 import SettingsElement from "./SettingsElement";
@@ -64,7 +64,7 @@ const WidgetSettingsComponent = (props: { bodyRef: any }) => {
 													knownComponent
 												);
 												EventHandler.emit(
-													"rerenderAll"
+													EventType.RERENDER_ALL
 												);
 											}}
 											key={index}

--- a/src/components/widgets/controlbar/WidgetComponentControlbar.tsx
+++ b/src/components/widgets/controlbar/WidgetComponentControlbar.tsx
@@ -7,7 +7,7 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import SkipNextIcon from "@mui/icons-material/SkipNext";
 import { useEffect, useState } from "react";
 import { widgetsDb } from "../../../utils/db";
-import EventHandler from "../../../utils/eventhandler";
+import EventHandler, { EventType } from "../../../utils/eventhandler";
 import { useSetting } from "../../../utils/eventhooks";
 import { KnownComponent } from "../../../utils/registry/types";
 import styles from "./controlbar.module.css";
@@ -33,7 +33,7 @@ function ControlBar(props: { blur: boolean; id: string }) {
 			<div className={styles.item__wrapper}>
 				<div
 					onClick={() =>
-						EventHandler.emit("settings_window_state", {
+						EventHandler.emit(EventType.SETTINGS_WINDOW_STATE, {
 							opened: true,
 						})
 					}
@@ -45,7 +45,7 @@ function ControlBar(props: { blur: boolean; id: string }) {
 			<div className={styles.item__wrapper}>
 				<div
 					onClick={() => {
-						EventHandler.emits(["skip_image", "playlist_refresh"]);
+						EventHandler.emits([EventType.SKIP_IMAGE, EventType.PLAYLIST_REFRESH]);
 						setUnlocked(true);
 					}}
 				>

--- a/src/utils/db.ts
+++ b/src/utils/db.ts
@@ -1,7 +1,5 @@
 import Dexie, { Table } from "dexie";
 import { useEffect, useState } from "react";
-import { downloadContent } from "./browserutils";
-import EventHandler from "./eventhandler";
 
 const asyncSleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -101,8 +99,6 @@ class WidgetDatabase extends Dexie {
 	}
 
 	setSetting(id: string, key: string, value: any) {
-		EventHandler.emit(`widget.${id}.${key}`, value);
-
 		key = `settings.${key}`;
 		this.widgets.update(id, { [key]: value });
 	}

--- a/src/utils/eventhandler.ts
+++ b/src/utils/eventhandler.ts
@@ -1,13 +1,15 @@
-interface CallBacks {
-    [eventName: string]: {
-        [id: string]: Function;
-    };
+export enum EventType {
+    QUEUE_REMOVE_IMAGE = "QUEUE_REMOVE_IMAGE",
+    SETTINGS_WINDOW_STATE = "SETTINGS_WINDOW_STATE",
+    RERENDER_ALL = "RERENDER_ALL",
+    SKIP_IMAGE = "SKIP_IMAGE",
+    PLAYLIST_REFRESH = "PLAYLIST_REFRESH",
 }
 
 const EventHandler = {
-    callbacks: {} as CallBacks,
+    callbacks: {} as { [key in EventType]: { [id: string]: Function } },
 
-    emit: (eventName: string, data: any=null) => {
+    emit: (eventName: EventType, data: any=null) => {
         console.debug("[Event] Event published: " + eventName);
         console.debug(data);
         
@@ -18,7 +20,7 @@ const EventHandler = {
         }
     },
 
-    emits: (eventNames: Array<string>, datas: Array<any>=[]) => {
+    emits: (eventNames: Array<EventType>, datas: Array<any>=[]) => {
         eventNames.forEach((eventName, index) => {
             if (datas === null) {
                 EventHandler.emit(eventName);
@@ -28,7 +30,7 @@ const EventHandler = {
         });
     },
 
-    on: (eventName: string, id: string, callback: Function) => {
+    on: (eventName: EventType, id: string, callback: Function) => {
         if (!EventHandler.callbacks[eventName]) {
             EventHandler.callbacks[eventName] = {};
         }
@@ -36,7 +38,7 @@ const EventHandler = {
         EventHandler.callbacks[eventName][id] = callback;
     },
 
-    off: (eventName: string, id: string) => {
+    off: (eventName: EventType, id: string) => {
         if (EventHandler.callbacks[eventName]) {
             delete EventHandler.callbacks[eventName][id];
         }

--- a/src/utils/eventhooks.ts
+++ b/src/utils/eventhooks.ts
@@ -2,6 +2,7 @@ import { useLiveQuery } from "dexie-react-hooks";
 import { useEffect, useState } from "react";
 import { widgetsDb } from "./db";
 import EventHandler from "./eventhandler";
+import { EventType } from './eventhandler';
 
 let SETTINGS_CACHE: { [key: string]: { [key: string]: any } } = {};
 
@@ -100,7 +101,7 @@ export const useWidget = (id: string): any => {
 };
 
 export const useEvent = (
-	event_name: string,
+	event_name: EventType,
 	identifier: string,
 	default_value?: any,
 	trigger_function?: Function


### PR DESCRIPTION
Havign strings as event names always felt pretty messy and so I changed all string event names to a general enum named `EventType` located in the EventHandler. I also removed the event emit from the database whenever a key changed as this isn't used anymore.

